### PR TITLE
Fix lucide-react cube import error

### DIFF
--- a/src/components/map/MapTools.tsx
+++ b/src/components/map/MapTools.tsx
@@ -8,12 +8,12 @@ import { Separator } from '@/components/ui/separator';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { 
-  Polygon, 
-  Move3d, 
+  Pentagon, 
+  Move, 
   Ruler, 
   Square, 
   Circle, 
-  Triangle, 
+  Play, 
   Trash2, 
   Download, 
   Upload,
@@ -331,7 +331,7 @@ const MapTools: React.FC<MapToolsProps> = ({
         className="absolute top-20 left-4 z-[1000] bg-slate-900/95 border-cyan-500/30 text-cyan-400"
         size="sm"
       >
-        <Move3d className="w-4 h-4 mr-2" />
+        <Move className="w-4 h-4 mr-2" />
         Tools
       </Button>
     );
@@ -342,7 +342,7 @@ const MapTools: React.FC<MapToolsProps> = ({
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <CardTitle className="text-cyan-400 text-sm flex items-center gap-2">
-            <Move3d className="w-4 h-4" />
+            <Move className="w-4 h-4" />
             {getTerminology('Tactical Tools', 'Map Tools')}
           </CardTitle>
           <Button
@@ -374,7 +374,7 @@ const MapTools: React.FC<MapToolsProps> = ({
                 onClick={() => startDrawing('polygon')}
                 className="text-xs"
               >
-                <Polygon className="w-3 h-3 mr-1" />
+                <Pentagon className="w-3 h-3 mr-1" />
                 Polygon
               </Button>
               <Button
@@ -383,7 +383,7 @@ const MapTools: React.FC<MapToolsProps> = ({
                 onClick={() => startDrawing('polyline')}
                 className="text-xs"
               >
-                <Move3d className="w-3 h-3 mr-1" />
+                <Move className="w-3 h-3 mr-1" />
                 Line
               </Button>
               <Button

--- a/src/components/pavement-scan/ModelViewer3D.tsx
+++ b/src/components/pavement-scan/ModelViewer3D.tsx
@@ -11,7 +11,7 @@ import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { 
-  Cube, 
+  Layers as LayersIcon, 
   RotateCcw, 
   ZoomIn, 
   ZoomOut, 
@@ -278,7 +278,7 @@ const ModelViewer3D: React.FC<ModelViewer3DProps> = ({ scanData, defects }) => {
           <div className="flex items-center justify-between">
             <div>
               <CardTitle className="flex items-center gap-2">
-                <Cube className="h-5 w-5" />
+                <LayersIcon className="h-5 w-5" />
                 3D Model Viewer
               </CardTitle>
               <CardDescription>

--- a/src/pages/OverWatch.tsx
+++ b/src/pages/OverWatch.tsx
@@ -9,7 +9,7 @@ import { Separator } from '@/components/ui/separator';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { Sidebar } from '@/components/Sidebar';
+import Sidebar from '@/components/Sidebar';
 import { Radar, Map, Layers, Navigation, Crosshair, Ruler, Camera, Users, Truck, Cloud, Thermometer, Eye, Settings, Target, RadioIcon as Radio, Activity, AlertTriangle, Zap } from 'lucide-react';
 import html2canvas from 'html2canvas';
 import MapTools from '@/components/map/MapTools';

--- a/src/pages/PavementScanPro.tsx
+++ b/src/pages/PavementScanPro.tsx
@@ -9,7 +9,7 @@ import { Separator } from "@/components/ui/separator";
 import { 
   Camera, 
   Scan, 
-  Cube, 
+  Layers, 
   Download, 
   Share, 
   AlertTriangle, 
@@ -261,7 +261,7 @@ const PavementScanPro = () => {
                     onClick={() => setScanningMode('complete')}
                     disabled={isScanning}
                   >
-                    <Cube className="h-4 w-4 mr-1" />
+                    <Layers className="h-4 w-4 mr-1" />
                     Complete
                   </Button>
                 </div>
@@ -365,7 +365,7 @@ const PavementScanPro = () => {
               </CardHeader>
               <CardContent className="space-y-2">
                 <Button variant="outline" size="sm" className="w-full">
-                  <Cube className="h-4 w-4 mr-1" />
+                  <Layers className="h-4 w-4 mr-1" />
                   View 3D Model
                 </Button>
                 <Button variant="outline" size="sm" className="w-full">


### PR DESCRIPTION
Replaces non-existent Lucide icons and corrects a default import to resolve runtime errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-057e3769-a54e-42bb-8975-669f98bcc91d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-057e3769-a54e-42bb-8975-669f98bcc91d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

