### PR TITLE
Fix fleet and field map connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,6 +163,10 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@asphalt/platform-sdk": {
+      "resolved": "packages/platform-sdk",
+      "link": true
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -10881,7 +10885,6 @@
     "packages/platform-sdk": {
       "name": "@asphalt/platform-sdk",
       "version": "0.1.0",
-      "extraneous": true,
       "devDependencies": {
         "typescript": "^5.8.3"
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ const App = () => (
                   <Route path="/intel-reports" element={<IntelReports />} />
                   <Route path="/pavement-scan-pro" element={<PavementScanPro />} />
                   <Route path="/overwatch" element={<OverWatch />} />
+                  <Route path="/map" element={<OverWatch />} />
                   <Route path="/settings" element={<Settings />} />
                   <Route path="/pavement-estimator" element={<Estimator />} />
                   <Route path="/client-portal" element={<ClientPortal />} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -46,7 +46,7 @@ const iconMap: Record<string, any> = {
 
 const defaultNav: NavItemConfig[] = [
   { name: "Dashboard", href: "/dashboard", icon: "LayoutDashboard" },
-  { name: "OverWatch Map", href: "/overwatch", icon: "Radar", badge: "LIVE" },
+  { name: "Unified Map", href: "/map", icon: "Radar", badge: "LIVE" },
   { name: "Mission Planning", href: "/mission-planning", icon: "Target" },
   { name: "Team Management", href: "/team-management", icon: "Users" },
   { name: "Analytics", href: "/analytics", icon: "BarChart3" },

--- a/src/pages/OverWatch.tsx
+++ b/src/pages/OverWatch.tsx
@@ -110,8 +110,8 @@ const mapServices: MapService[] = [
     id: "mapbox-streets",
     name: "Mapbox Streets",
     url:
-      typeof import.meta !== "undefined" && (import.meta as any).env?.VITE_MAPBOX_API_KEY
-        ? `https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=${(import.meta as any).env.VITE_MAPBOX_API_KEY}`
+      typeof import.meta !== "undefined" && (import.meta as any).env?.VITE_MAPBOX_TOKEN
+        ? `https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=${(import.meta as any).env.VITE_MAPBOX_TOKEN}`
         : "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
     attribution: "© Mapbox",
     icon: <Map className="w-4 h-4" />,
@@ -120,8 +120,8 @@ const mapServices: MapService[] = [
     id: "mapbox-satellite",
     name: "Mapbox Satellite",
     url:
-      typeof import.meta !== "undefined" && (import.meta as any).env?.VITE_MAPBOX_API_KEY
-        ? `https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/{z}/{x}/{y}?access_token=${(import.meta as any).env.VITE_MAPBOX_API_KEY}`
+      typeof import.meta !== "undefined" && (import.meta as any).env?.VITE_MAPBOX_TOKEN
+        ? `https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/{z}/{x}/{y}?access_token=${(import.meta as any).env.VITE_MAPBOX_TOKEN}`
         : "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
     attribution: "© Mapbox",
     icon: <Eye className="w-4 h-4" />,
@@ -430,7 +430,7 @@ const OverWatch: React.FC = () => {
               <div className="flex items-center gap-2">
                 <Radar className="w-6 h-6 text-cyan-400" />
                 <h1 className="text-xl font-bold text-cyan-400">
-                  {getTerminology("OverWatch Command Center", "OverWatch Control Hub")}
+                  {getTerminology("Unified Map Command Center", "Unified Map Control Hub")}
                 </h1>
               </div>
               <Badge variant="outline" className="text-green-400 border-green-400">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -483,11 +483,13 @@ export class GPSTrackingService {
 
   private connectWebSocket(): void {
     try {
-      const wsUrl = API_CONFIG.GPS_TRACKING_URL.replace("https://", "wss://").replace(
-        "http://",
-        "ws://",
-      );
-      this.websocket = new WebSocket(`${wsUrl}/realtime`);
+      const wsUrl = (API_CONFIG.FLEET_WEBSOCKET_URL || "").startsWith("ws")
+        ? API_CONFIG.FLEET_WEBSOCKET_URL
+        : API_CONFIG.GPS_TRACKING_URL.replace("https://", "wss://").replace(
+            "http://",
+            "ws://",
+          ) + "/realtime";
+      this.websocket = new WebSocket(wsUrl);
 
       this.websocket.onopen = () => {
         console.log("GPS WebSocket connected");


### PR DESCRIPTION
Unifies the map view into a single page and corrects fleet data integration to address missing and miswired subsystems.

This PR consolidates the map experience under a new `/map` route, updates navigation, standardizes the Mapbox environment variable key, and ensures the correct WebSocket URL is prioritized for real-time fleet data, resolving issues with disparate map views and data connectivity.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e91ba96-c44a-4f42-b8a1-c124532ddc3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e91ba96-c44a-4f42-b8a1-c124532ddc3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

