### PR TITLE
Handle vite react swc preamble error

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,16 @@
 
   <body>
     <div id="root"></div>
+    <script type="module">
+      if (import.meta.env && import.meta.env.DEV) {
+        import('/@react-refresh').then(({ default: RefreshRuntime }) => {
+          RefreshRuntime.injectIntoGlobalHook(window)
+          window.$RefreshReg$ = () => {}
+          window.$RefreshSig$ = () => (type) => type
+          window.__vite_plugin_react_preamble_installed__ = true
+        }).catch(() => {})
+      }
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Add a dev-only React Fast Refresh preamble to `index.html` to resolve the `@vitejs/plugin-react-swc` runtime error.

Although `@vitejs/plugin-react` is used locally, the runtime error indicates that some environments expect the preamble required by `@vitejs/plugin-react-swc`. This change ensures the preamble is present in development, preventing the "can't detect preamble" error without affecting production builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-907b9b3e-3acc-4eab-bb6b-8e94de4a577a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-907b9b3e-3acc-4eab-bb6b-8e94de4a577a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

