### PR TITLE
Fix generic page error message

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { AdvancedThemeProvider } from "@/contexts/AdvancedThemeContext";
 import { Suspense, lazy } from "react";
@@ -35,6 +35,41 @@ const MobileCompanion = lazy(() => import("./pages/MobileCompanion"));
 
 const queryClient = new QueryClient();
 
+function RoutedApp() {
+  const location = useLocation();
+  return (
+    <>
+      <RouteSound />
+      <ErrorBoundary resetKey={location.pathname}>
+        <Suspense fallback={<div className="flex items-center justify-center min-h-screen"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div></div>}>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/mission-planning" element={<MissionPlanning />} />
+            <Route path="/team-management" element={<TeamManagement />} />
+            <Route path="/analytics" element={<Analytics />} />
+            <Route path="/communications" element={<Communications />} />
+            <Route path="/intel-reports" element={<IntelReports />} />
+            <Route path="/pavement-scan-pro" element={<PavementScanPro />} />
+            <Route path="/overwatch" element={<OverWatch />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/pavement-estimator" element={<Estimator />} />
+            <Route path="/client-portal" element={<ClientPortal />} />
+            <Route path="/contractor-portal" element={<ContractorPortal />} />
+            <Route path="/theme-customizer" element={<AdvancedThemeCustomizer />} />
+            <Route path="/builder" element={<Builder />} />
+            <Route path="/fleet-field-ops" element={<OperationsSuite />} />
+            <Route path="/operations-suite" element={<OperationsSuite />} />
+            <Route path="/mobile-companion" element={<MobileCompanion />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
+      </ErrorBoundary>
+    </>
+  );
+}
+
 const App = () => (
   <AdvancedThemeProvider defaultTheme="military-tactical">
     <ThemeProvider
@@ -44,42 +79,16 @@ const App = () => (
       disableTransitionOnChange
     >
       <QueryClientProvider client={queryClient}>
-                 <TooltipProvider>
-           <Toaster />
-           <Sonner />
-                       <SoundManager />
-                         <UiSoundBindings />
-            <EffectsOverlay />
-            <ThemeBackground />
-           <BrowserRouter>
-             <RouteSound />
-             <ErrorBoundary>
-               <Suspense fallback={<div className="flex items-center justify-center min-h-screen"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div></div>}>
-                <Routes>
-                <Route path="/" element={<Index />} />
-                <Route path="/dashboard" element={<Dashboard />} />
-                <Route path="/mission-planning" element={<MissionPlanning />} />
-                <Route path="/team-management" element={<TeamManagement />} />
-                <Route path="/analytics" element={<Analytics />} />
-                <Route path="/communications" element={<Communications />} />
-                <Route path="/intel-reports" element={<IntelReports />} />
-                <Route path="/pavement-scan-pro" element={<PavementScanPro />} />
-                                 <Route path="/overwatch" element={<OverWatch />} />
-                 <Route path="/settings" element={<Settings />} />
-                 <Route path="/pavement-estimator" element={<Estimator />} />
-                 <Route path="/client-portal" element={<ClientPortal />} />
-                 <Route path="/contractor-portal" element={<ContractorPortal />} />
-                                  <Route path="/theme-customizer" element={<AdvancedThemeCustomizer />} />
-                   <Route path="/builder" element={<Builder />} />
-                 <Route path="/fleet-field-ops" element={<OperationsSuite />} />
-                 <Route path="/operations-suite" element={<OperationsSuite />} />
-                 <Route path="/mobile-companion" element={<MobileCompanion />} />
-                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-                <Route path="*" element={<NotFound />} />
-                </Routes>
-               </Suspense>
-              </ErrorBoundary>
-            </BrowserRouter>
+        <TooltipProvider>
+          <Toaster />
+          <Sonner />
+          <SoundManager />
+          <UiSoundBindings />
+          <EffectsOverlay />
+          <ThemeBackground />
+          <BrowserRouter>
+            <RoutedApp />
+          </BrowserRouter>
         </TooltipProvider>
       </QueryClientProvider>
     </ThemeProvider>

--- a/src/components/effects/EffectsOverlay.tsx
+++ b/src/components/effects/EffectsOverlay.tsx
@@ -90,8 +90,11 @@ export default function EffectsOverlay() {
     return () => media.removeEventListener('change', onChange);
   }, []);
 
-  const isLowPower = currentTheme?.performance.quality === 'low';
-  const enableVisuals = currentTheme?.performance.enableAnimations !== false && !isLowPower && !reducedMotion;
+  // If theme is not yet available, do not render overlay
+  if (!currentTheme) return null;
+
+  const isLowPower = currentTheme?.performance?.quality === 'low';
+  const enableVisuals = !!currentTheme?.performance?.enableAnimations && !isLowPower && !reducedMotion;
 
   if (!enableVisuals || settings.minimal) return null;
 

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 interface ErrorBoundaryProps {
   fallback?: React.ReactNode;
   children: React.ReactNode;
+  resetKey?: unknown;
 }
 
 interface ErrorBoundaryState {
@@ -24,6 +25,12 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
     console.error('ErrorBoundary caught an error', error);
   }
 
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    if (prevProps.resetKey !== this.props.resetKey && this.state.hasError) {
+      this.setState({ hasError: false });
+    }
+  }
+
   render() {
     if (this.state.hasError) {
       return this.props.fallback ?? (
@@ -31,7 +38,10 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
           <div className="max-w-md text-center space-y-3">
             <h1 className="text-2xl font-semibold">Something went wrong</h1>
             <p className="text-muted-foreground">Please refresh the page or try again.</p>
-            <button className="px-4 py-2 rounded bg-primary text-primary-foreground" onClick={() => location.reload()}>Reload</button>
+            <div className="flex items-center justify-center gap-2">
+              <button className="px-4 py-2 rounded bg-primary text-primary-foreground" onClick={() => location.reload()}>Reload</button>
+              <button className="px-4 py-2 rounded border" onClick={() => this.setState({ hasError: false })}>Try Again</button>
+            </div>
           </div>
         </div>
       );


### PR DESCRIPTION
Implement error boundary reset on navigation and add a 'Try Again' button to improve app resilience.

A single error previously caused the "Something went wrong" fallback to display on all subsequent pages, even after navigation, as the error boundary state wasn't reset. This change ensures the error boundary resets when the route changes, allowing users to navigate away from an erroring page, and also provides a direct "Try Again" option to clear the error state without a full page refresh. Additionally, a null check was added to `EffectsOverlay` to prevent potential early render errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9e2b7ca-7c47-4281-891d-78ed48bb0150">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9e2b7ca-7c47-4281-891d-78ed48bb0150">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

