### PR TITLE
Fix vite swc preamble detection error

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,17 +20,7 @@
 
   <body>
     <div id="root"></div>
-    <script type="module">
-      // React Fast Refresh preamble (sync) for @vitejs/plugin-react-swc
-      // Must run before any React code
-      if (import.meta && import.meta.env && import.meta.env.DEV) {
-        import RefreshRuntime from "/@react-refresh";
-        RefreshRuntime.injectIntoGlobalHook(window);
-        window.$RefreshReg$ = () => {};
-        window.$RefreshSig$ = () => (type) => type;
-        window.__vite_plugin_react_preamble_installed__ = true;
-      }
-    </script>
+
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
 // https://vitejs.dev/config/

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import react from '@vitejs/plugin-react-swc';
 import path from 'path';
 
 export default defineConfig({


### PR DESCRIPTION
Switched to `@vitejs/plugin-react-swc` and removed the manual React Refresh preamble to fix detection errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-db7f7cac-39fd-4ab2-a332-ff4f06bf1e13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db7f7cac-39fd-4ab2-a332-ff4f06bf1e13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

