### PR TITLE
Create unified Overwatch map page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ function RoutedApp() {
             <Route path="/intel-reports" element={<IntelReports />} />
             <Route path="/pavement-scan-pro" element={<PavementScanPro />} />
             <Route path="/overwatch" element={<OverWatch />} />
+            <Route path="/maps" element={<OverWatch />} />
             <Route path="/settings" element={<Settings />} />
             <Route path="/pavement-estimator" element={<Estimator />} />
             <Route path="/client-portal" element={<ClientPortal />} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -47,6 +47,7 @@ const iconMap: Record<string, any> = {
 const defaultNav: NavItemConfig[] = [
   { name: 'Dashboard', href: '/dashboard', icon: 'LayoutDashboard' },
   { name: 'OverWatch Map', href: '/overwatch', icon: 'Radar', badge: 'LIVE' },
+  { name: 'Maps (All Features)', href: '/maps', icon: 'Radar' },
   { name: 'Mission Planning', href: '/mission-planning', icon: 'Target' },
   { name: 'Team Management', href: '/team-management', icon: 'Users' },
   { name: 'Analytics', href: '/analytics', icon: 'BarChart3' },

--- a/src/pages/OverWatch.tsx
+++ b/src/pages/OverWatch.tsx
@@ -469,6 +469,14 @@ const OverWatch: React.FC = () => {
               variant="outline"
               size="sm"
               className="bg-slate-800 border-slate-600 text-cyan-400"
+              onClick={() => {
+                html2canvas(document.body).then(canvas => {
+                  const link = document.createElement('a');
+                  link.download = `overwatch-screenshot-${Date.now()}.png`;
+                  link.href = canvas.toDataURL();
+                  link.click();
+                });
+              }}
             >
               <Camera className="w-4 h-4 mr-2" />
               Snap Picture


### PR DESCRIPTION
Add a dedicated `/maps` route and sidebar entry for the unified OverWatch map page and enable screenshot functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-32c5f4b6-bd98-466e-a9e4-482d906a2b2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32c5f4b6-bd98-466e-a9e4-482d906a2b2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

