### PR TITLE
Change non-sidebar menus to horizontal layout

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -46,7 +46,7 @@ const Header = () => {
 
         {isMenuOpen && (
           <div className="md:hidden mt-4 pb-4 border-t border-border">
-            <nav className="flex flex-col space-y-4 pt-4">
+            <nav className="flex items-center gap-4 overflow-x-auto whitespace-nowrap py-4">
               <a href="#features" className="text-foreground hover:text-primary transition-colors">
                 Features
               </a>
@@ -56,7 +56,7 @@ const Header = () => {
               <a href="#contact" className="text-foreground hover:text-primary transition-colors">
                 Contact
               </a>
-              <Link to="/dashboard">
+              <Link to="/dashboard" className="shrink-0">
                 <Button variant="default" className="bg-gradient-to-r from-primary to-accent">
                   Launch System
                 </Button>


### PR DESCRIPTION
Convert the mobile header menu to a horizontal, scrollable layout to prevent it from being obscured by other content.

---
<a href="https://cursor.com/background-agent?bcId=bc-299cbff9-b730-4ebe-a8f0-a41ac9dd5e53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-299cbff9-b730-4ebe-a8f0-a41ac9dd5e53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

